### PR TITLE
get working in modern ruby versions

### DIFF
--- a/dassets-erb.gemspec
+++ b/dassets-erb.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("dassets", ["~> 0.13.2"])
+  gem.add_dependency("dassets", ["~> 0.14.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,9 +7,19 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-ENV['DASSETS_TEST_MODE']   = 'yes'
-
 require 'test/support/factory'
+
 class Assert::Context
-  setup{ @factory = Dassets::Erb::Factory }
+  setup{ @factory = Factory }
 end
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end
+
+ENV['DASSETS_TEST_MODE']   = 'yes'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,20 +1,20 @@
-module Dassets::Erb
+require 'assert/factory'
 
-  module Factory
-    module_function
+module Factory
+  extend Assert::Factory
 
-    def name
-      "Joe"
-    end
+  module_function
 
-    def erb
-      "hello, <%= Dassets::Erb::Factory.name %>!"
-    end
+  def name
+    "Joe"
+  end
 
-    def erb_compiled
-      "hello, Joe!"
-    end
+  def erb
+    "hello, <%= Factory.name %>!"
+  end
 
+  def erb_compiled
+    "hello, Joe!"
   end
 
 end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

Note: I also reworked the support Factory to be more up to our
latest conventions.  This caused no behavior changes, though.

@jcredding ready for review.