### PR TITLE
support configuring on files without an ERB extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Dassets::Erb
 
-Dassets [engine](https://github.com/redding/dassets#compiling) for compiling dynamic assets written in Erb.
+Dassets [engine](https://github.com/redding/dassets#compiling) to compile dynamic asset files written with ERB.
+
+See [Dassets::Erubi](https://github.com/redding/dassets-erubi) for a clone that uses [Erubi](https://github.com/jeremyevans/erubi) to do the compilation.
 
 ## Usage
 

--- a/dassets-erb.gemspec
+++ b/dassets-erb.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version     = Dassets::Erb::VERSION
   gem.authors     = ["Kelly Redding", "Collin Redding"]
   gem.email       = ["kelly@kellyredding.com", "collin.redding@me.com"]
-  gem.summary     = %q{Dassets engine for compiling Erb}
-  gem.description = %q{Dassets engine for compiling Erb}
+  gem.summary     = %q{Dassets engine to compile ERB.}
+  gem.description = %q{Dassets engine fo compile ERB.}
   gem.homepage    = "http://github.com/redding/dassets-erb"
   gem.license     = "MIT"
 

--- a/lib/dassets-erb.rb
+++ b/lib/dassets-erb.rb
@@ -6,8 +6,14 @@ require "dassets-erb/version"
 
 module Dassets::Erb; end
 class Dassets::Erb::Engine < Dassets::Engine
+  def self.ERB_EXTENSIONS
+    ["erb", "erubis", "erubi"]
+  end
+
   def ext(input_ext)
-    ""
+    return "" if self.class.ERB_EXTENSIONS.include?(input_ext)
+
+    input_ext
   end
 
   def compile(input_content)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,8 +9,4 @@ require "pry"
 
 require "test/support/factory"
 
-class Assert::Context
-  setup{ @factory = Factory }
-end
-
 ENV["DASSETS_TEST_MODE"] = "yes"

--- a/test/unit/dassets-erb_tests.rb
+++ b/test/unit/dassets-erb_tests.rb
@@ -3,17 +3,28 @@ require "dassets-erb"
 
 require "dassets/engine"
 
-class Dassets::Erb::Engine
+module Dassets::Erb
   class UnitTests < Assert::Context
-    desc "Dassets::Erb::Engine"
+    desc "Dassets::Erb"
     subject { unit_class }
 
-    let(:unit_class) { Dassets::Erb::Engine }
+    let(:unit_class) { Dassets::Erb }
   end
 
-  class InitTests < UnitTests
+  class EngineTests < UnitTests
+    desc "Engine"
+    subject { engine_class }
+
+    let(:engine_class) { unit_class::Engine }
+
+    should "know its ERB extensions" do
+      assert_that(subject.ERB_EXTENSIONS).equals(["erb", "erubis", "erubi"])
+    end
+  end
+
+  class EngineInitTests < EngineTests
     desc "when init"
-    subject { unit_class.new }
+    subject { engine_class.new }
 
     should "be a Dassets engine" do
       assert_that(subject).is_kind_of(Dassets::Engine)
@@ -30,7 +41,7 @@ class Dassets::Erb::Engine
     end
 
     should "compile any input content as ERB" do
-      assert_equal @factory.erb_compiled, subject.compile(@factory.erb)
+      assert_equal Factory.erb_compiled, subject.compile(Factory.erb)
     end
   end
 end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -21,10 +21,12 @@ class Dassets::Erb::Engine
       assert_that(subject).responds_to("compile")
     end
 
-    should "remove any input extension" do
+    should "only remove ERB-like input extensions" do
       assert_that(subject.ext("erb")).equals("")
       assert_that(subject.ext("erubis")).equals("")
-      assert_that(subject.ext("whatever")).equals("")
+      assert_that(subject.ext("erubi")).equals("")
+      assert_that(subject.ext("css")).equals("css")
+      assert_that(subject.ext("js")).equals("js")
     end
 
     should "compile any input content as ERB" do


### PR DESCRIPTION
This allows you to implicitly ERB all files with e.g. a .css or
.js extension and not alter the extension of the file. However, if
the registered extension is .erb, .erubis, or .erubi, it will be
removed as it did previously.

# Other Changes

### update README, tests based on latest conventions

I noticed these while using this code for reference while writing
Dassets::Erubi.